### PR TITLE
bug (validate password on reset) a password should include numbers an…

### DIFF
--- a/authors/apps/authentication/fixtures/pass_reset.json
+++ b/authors/apps/authentication/fixtures/pass_reset.json
@@ -6,7 +6,7 @@
             "username": "sanya",
             "email": "sanyakenneth@gmail.com",
             "email_verified": true,
-            "password": "pbkdf2_sha256$120000$RLkaJYAyp0Dq$+2V+D1qXP5P1UuEjLxaRAorMiw2khCxKevg+/YrCAyI=",
+            "password": "pbkdf2_sha256$120000$bXWlehrQpomQ$6tTNhFZeNNa9i1/j4lEOA5AOGu/scVVw20dPKUMes4c=",
             "created_at": "2013-03-23 00:03:00",
             "updated_at": "2013-03-23 01:02:00"
         }

--- a/authors/apps/authentication/tests/reset_password_base.py
+++ b/authors/apps/authentication/tests/reset_password_base.py
@@ -19,3 +19,13 @@ class BaseTestCase(APITestCase):
                 "password": "abc?54321",
                 "confirm_password": "abc?54321"
             }
+
+        self.reset_invalid_new_passwords_data = {
+                "password": "987654321",
+                "confirm_password": "987654321"
+            }
+
+        self.reset_same_password_data = {
+                "password": "?ad87654321",
+                "confirm_password": "?ad87654321"
+            }

--- a/authors/apps/authentication/tests/test_password_reset.py
+++ b/authors/apps/authentication/tests/test_password_reset.py
@@ -33,3 +33,44 @@ class UserSignUpTestCase(BaseTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['message'], 'Password reset successfull.')
+
+    def test_reset_wrong_token(self):
+        """
+        test a post new password to reset
+        """
+
+        url = reverse('password_reset_token', kwargs={'token':'ytokengoeshere'})
+        response = self.client.post(url, self.reset_new_passwords_data)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data['message'], 'Ivalid link. Regenerate a reset password token')
+
+    def test_post_wrong_new_password(self):
+        """
+        test post an invalid new password to reset
+        """
+
+        url = reverse('password_reset_token', kwargs={'token':'mytokengoeshere'})
+        response = self.client.post(url, self.reset_invalid_new_passwords_data)
+
+        error_message = {
+                    "password": [
+                        "Password should include numbers and alphabets and one special character"
+                    ]
+            }
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['errors'], error_message)
+
+    def test_post_same_password(self):
+        """
+        test post an invalid new password to reset
+        """
+
+        url = reverse('password_reset_token', kwargs={'token':'mytokengoeshere'})
+        response = self.client.post(url, self.reset_same_password_data)
+
+        error_message = "New password should be different from previous password."
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['errors'][0], error_message)


### PR DESCRIPTION
#### What does the PR do?
- Adds password validation on reset.
#### Description of Task to be completed?
- On reset, the password is checked for numbers, alphabets, and special characters. I should have at least one of each to be valid

#### How should this be manually tested?
Given you have an account, request to reset your password with this endpoint:
POST: /api/reset_password/
```
{
	"email": "3dnamargarita@gmail.com"
}
```
Follow the link sent to your email to get to the page where you can add new passwords from:
If using postman, uses the endpoint below replacing the word 'token' with the token sent to your email.
/api/reset_password/token/
```
{
	"password": "987654321",
	"confirm_password": "987654321"
}
```
Try out an invalid password to test this.

[#165737880](https://www.pivotaltracker.com/story/show/165737880)
